### PR TITLE
Add platform to bundle lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   jekyll


### PR DESCRIPTION
In order to work on Digital Ocean, ran `bundle lock --add-platform x86_64-linux` to add the required platform.